### PR TITLE
ci(github-actions): rename dependabot pr jobs

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -14,7 +14,15 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['', ...componentNames, 'storybook', 'cypress', 'npm'],
+      [
+        '',
+        ...componentNames,
+        'cypress',
+        'github-actions',
+        'npm',
+        'storybook',
+        'vite',
+      ],
     ],
   },
 }

--- a/.cz-config.js
+++ b/.cz-config.js
@@ -57,7 +57,15 @@ module.exports = {
       'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n',
     confirmCommit: 'Are you sure you want to proceed with the commit above?',
   },
-  scopes: ['', ...componentNames, 'storybook', 'cypress', 'npm'],
+  scopes: [
+    '',
+    ...componentNames,
+    'cypress',
+    'github-actions',
+    'npm',
+    'storybook',
+    'vite',
+  ],
   allowCustomScopes: false,
   allowBreakingChanges: ['feat', 'fix'],
 

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -8,12 +8,9 @@ on:
     branches:
       - 'dependabot/**'
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
   # This job lints all files with ESLint.
-  lint:
+  dependabot-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,7 +29,7 @@ jobs:
         run: npm run lint
 
   # This job runs all Cypress tests.
-  cypress-test:
+  dependabot-cypress-test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -54,7 +51,8 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: '.nvmrc'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: E2E tests on Node v${{ matrix.node }}
         uses: cypress-io/github-action@v2


### PR DESCRIPTION
So they can be differentiated from the regular test jobs.