### PR TITLE
feat(UsaIcon): switch from deprecated `xlink:href` attribute to `href`

### DIFF
--- a/src/components/UsaIcon/UsaIcon.test.js
+++ b/src/components/UsaIcon/UsaIcon.test.js
@@ -17,7 +17,7 @@ describe('UsaIcon', () => {
 
     cy.get('svg > use').should(
       'have.attr',
-      'xlink:href',
+      'href',
       '/assets/img/sprite.svg#flag',
     )
   })
@@ -44,7 +44,7 @@ describe('UsaIcon', () => {
       .and('have.attr', 'focusable', 'true')
       .and('have.class', 'usa-icon--size-3')
 
-    cy.get('svg > use').should('have.attr', 'xlink:href', '/test.svg#github')
+    cy.get('svg > use').should('have.attr', 'href', '/test.svg#github')
   })
 
   it('custom slot content is used', () => {

--- a/src/components/UsaIcon/UsaIcon.vue
+++ b/src/components/UsaIcon/UsaIcon.vue
@@ -62,6 +62,6 @@ const iconHref = computed(() => `${svgSpritePath}#${props.name}`)
     :focusable="focusable"
   >
     <slot name="title"></slot>
-    <use :xlink:href="iconHref"></use>
+    <use :href="iconHref"></use>
   </svg>
 </template>


### PR DESCRIPTION
This aligns with USWDS 3.11.0 latest markup changes: https://github.com/uswds/uswds/releases/tag/v3.11.0